### PR TITLE
Dockerfile[DevOps]:Adding-Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,44 @@
+# ---- Build Stage ----
+FROM golang:1.24-alpine AS builder
+
+WORKDIR /app
+
+# Install CA certs and create non-root user
+RUN apk add --no-cache ca-certificates git && \
+    addgroup -S appgroup && \
+    adduser -S -D -G appgroup -s /bin/sh -u 1001 appuser
+
+# Copy go.mod first for better caching
+COPY go.mod ./
+
+# Download dependencies
+RUN go mod download
+
+# Copy source code
+COPY . .
+
+# Build statically-linked binary
+RUN CGO_ENABLED=0 GOOS=linux go build \
+    -ldflags="-w -s" \
+    -a -installsuffix cgo \
+    -o backend main.go
+
+# ---- Final Stage ----
+FROM scratch AS final
+
+WORKDIR /
+
+# Copy essential files from builder
+COPY --from=builder /app/backend /backend
+COPY --from=builder /etc/passwd /etc/passwd
+COPY --from=builder /etc/group /etc/group
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+
+# Use non-root user
+USER 1001
+
+# Expose port
+EXPOSE 8080
+
+# Run the binary
+ENTRYPOINT ["/backend"]


### PR DESCRIPTION
This pull request introduces a new `Dockerfile` to streamline the containerization of the backend application. The changes implement a multi-stage build process to optimize the image size and security by using a non-root user and a statically-linked binary.

### Containerization setup:

* **Multi-stage build process**: The `Dockerfile` uses a builder stage with `golang:1.24-alpine` to compile the Go application and a final stage based on `scratch` for a minimal production image.
* **Non-root user**: A non-root user (`appuser`) is created in the builder stage and used in the final stage to enhance security.
* **Optimized binary**: The Go application is built as a statically-linked binary with `CGO_ENABLED=0` and size-reducing flags (`-w -s`).

### Additional improvements:

* **Dependency caching**: The `go.mod` file is copied first to leverage Docker's layer caching for dependency downloads.
* **Essential files inclusion**: Certificates and user/group files are copied from the builder stage to the final stage to ensure the application runs securely and correctly.