### PR TITLE
Adding-Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,74 @@
+.PHONY: install-local uninstall-local help dev test server clean setup status
+
+# Local bin directory inside project
+LOCAL_BIN := $(CURDIR)/bin
+SCRIPT := $(CURDIR)/scripts/run_local.sh
+LINK := $(LOCAL_BIN)/run_local
+
+# Add local bin to PATH for this make session
+export PATH := $(LOCAL_BIN):$(PATH)
+
+# Default target
+all: help
+
+install-local: ## Symlink scripts/run_local.sh to bin/run_local
+	@echo "🔧 Installing run_local locally..."
+	@mkdir -p $(LOCAL_BIN)
+	@if [ ! -f "$(SCRIPT)" ]; then \
+		echo "❌ Error: $(SCRIPT) not found"; \
+		exit 1; \
+	fi
+	@ln -sf $(SCRIPT) $(LINK)
+	@chmod +x $(SCRIPT) $(LINK)
+	@echo "✅ Installed: run_local -> $(SCRIPT)"
+	@echo "💡 To use in your shell, run:"
+	@echo "   export PATH=\"$(LOCAL_BIN):\\$$PATH\""
+	@echo "   run_local --help"
+
+uninstall-local: ## Remove the local symlink
+	@rm -f $(LINK)
+	@echo "✅ Uninstalled local run_local"
+
+setup: install-local ## Full project setup (alias for install-local)
+
+dev: install-local ## Run in development mode
+	@echo "🚀 Starting development server..."
+	@run_local --debug
+
+test: install-local ## Run tests
+	@echo "🧪 Running tests..."
+	@run_local --test
+
+server: install-local ## Run server in background
+	@echo "⚡ Starting background server..."
+	@run_local --server
+
+clean: uninstall-local ## Clean up local installation
+	@if [ -d "$(LOCAL_BIN)" ] && [ -z "$(ls -A $(LOCAL_BIN))" ]; then \
+		rmdir $(LOCAL_BIN); \
+		echo "✅ Removed empty bin directory"; \
+	fi
+
+status: ## Show installation status
+	@echo "📋 Installation Status:"
+	@echo "   Script: $(SCRIPT)"
+	@if [ -f "$(SCRIPT)" ]; then echo "   ✅ Script exists"; else echo "   ❌ Script missing"; fi
+	@echo "   Link: $(LINK)"
+	@if [ -L "$(LINK)" ]; then echo "   ✅ Symlink exists"; else echo "   ❌ Symlink missing"; fi
+	@if command -v run_local >/dev/null 2>&1; then \
+		echo "   ✅ run_local command available"; \
+	else \
+		echo "   ⚠️  run_local not in PATH"; \
+	fi
+
+help: ## Show Makefile command usage
+	@echo ""
+	@echo "🛠️  Makefile Commands for Go Backend Project"
+	@echo "==========================================="
+	@grep -E '^[a-zA-Z_-]+:.*?## .+$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-18s\033[0m %s\n", $$1, $$2}'
+	@echo ""
+	@echo "📦 Project Structure:"
+	@echo "  scripts/run_local.sh  → Main script"
+	@echo "  bin/run_local         → Symlink created by 'make install-local'"
+	@echo ""
+	@echo "💡 Tip: To see runtime options, run: \033[33mrun_local --help\033[0m"

--- a/README.md
+++ b/README.md
@@ -1,0 +1,69 @@
+## 🛠️ Makefile Usage
+
+This project includes a [Makefile](Makefile) to simplify common development tasks such as running the server, executing tests, and managing local scripts.
+
+### 📋 Available Commands
+
+- **Setup & Install**
+  - `make setup` or `make install-local`  
+    Installs the `run_local` script as a symlink in the `bin/` directory for easy access.
+
+- **Run the Server**
+  - `make server`  
+    Builds and runs the server in the background.
+
+  - `make dev`  
+    Runs the server in the foreground with debug output.
+
+- **Run Tests**
+  - `make test`  
+    Runs all Go tests in the project.
+
+- **Clean Up**
+  - `make clean`  
+    Removes the local symlink and cleans up the `bin/` directory if empty.
+
+- **Status**
+  - `make status`  
+    Shows the installation status of the `run_local` script and symlink.
+
+- **Help**
+  - `make help`  
+    Lists all available Makefile commands and their descriptions.
+
+### 🚀 Quick Start
+
+1. **Install the local script:**
+   ```sh
+   make setup
+   ```
+
+2. **Run the server in development mode:**
+   ```sh
+   make dev
+   ```
+
+3. **Run tests:**
+   ```sh
+   make test
+   ```
+
+4. **Check status or get help:**
+   ```sh
+   make status
+   make help
+   ```
+
+### 💡 Notes
+
+- The `run_local` script is symlinked to `bin/run_local` and can be added to your `PATH` for convenience:
+  ```sh
+  export PATH="$PWD/bin:$PATH"
+  ```
+- All commands are designed to work cross-platform and will ensure dependencies are installed as needed.
+- For advanced usage and options, run:
+  ```sh
+  run_local --help
+  ```
+
+See the [Makefile](Makefile) for full details and customization


### PR DESCRIPTION
This pull request introduces a `Makefile` to streamline development workflows and updates the `README.md` to document its usage. The `Makefile` provides commands for tasks such as setting up the project, running the server, executing tests, cleaning up, and checking the installation status of local scripts.

### Makefile additions:

* **Streamlined development commands**: Added targets like `install-local`, `dev`, `test`, `server`, `clean`, and `status` to simplify common tasks such as running the server, testing, and managing local scripts.
* **Help and documentation**: Included a `help` target to list all available commands with descriptions directly from the `Makefile`.

### Documentation updates:

* **Usage guide**: Updated `README.md` with a detailed explanation of the `Makefile` commands, including setup, running the server, testing, cleaning up, and checking status.
* **Quick start instructions**: Added step-by-step instructions for using the `Makefile` to install the script, run the server, and execute tests.